### PR TITLE
Updated the file to use Lwt_stream.t in place of using Lwt_async+Lwt_mvar.t

### DIFF
--- a/lib/conntest.ml
+++ b/lib/conntest.ml
@@ -507,7 +507,7 @@ module Make
             ... the order of Lwt_mvar.put waiters is kept
               .. (will be okay if not ordered, as Ring reorders)
           *)
-          Lwt.async (fun () -> Lwt_mvar.put flow.sink ring_field);
+          Lwt_stream.push flow.sink ring_field;
           Lwt.return_unit
       end
 

--- a/lib/conntest.ml
+++ b/lib/conntest.ml
@@ -287,7 +287,7 @@ module Make
               O.Listen.set_delayed_packets ~pier delayed_packets;
             )
         end;
-        Lwt_stream.get flow.sink >>= fun ring_field ->
+        Lwt_stream.get_available flow.sink >>= fun ring_field ->
         begin match ring_field.meta with
           | `Ack ack_index ->
             Log.debug (fun m -> m "feed_source: received `Ack (i=%d)"

--- a/lib/conntest.ml
+++ b/lib/conntest.ml
@@ -287,7 +287,7 @@ module Make
               O.Listen.set_delayed_packets ~pier delayed_packets;
             )
         end;
-        Lwt_mvar.take flow.sink >>= fun ring_field ->
+        Lwt_stream.get flow.sink >>= fun ring_field ->
         begin match ring_field.meta with
           | `Ack ack_index ->
             Log.debug (fun m -> m "feed_source: received `Ack (i=%d)"

--- a/lib/conntest.ml
+++ b/lib/conntest.ml
@@ -167,7 +167,7 @@ module Make
 
     type partial_flow = {
       is_client : bool;
-      sink : ring_field Lwt_mvar.t;
+      sink : ring_field Lwt_stream.t;
       source : (Cstruct.t Mirage_flow.or_eof, err) result bounded_stream;
       port : int;
       pier : Ipaddr.t;
@@ -181,7 +181,7 @@ module Make
     (*> goto maybe; [sink, source, feeder] could be a single abstraction*)
     type t = {
       is_client : bool;
-      sink : ring_field Lwt_mvar.t;
+      sink : ring_field Lwt_stream.t;
       source : (Cstruct.t Mirage_flow.or_eof, err) result bounded_stream;
       feeder : unit Lwt.t;
       port : int;


### PR DESCRIPTION
Updated the file to use Lwt_stream.t in place of using Lwt_async+Lwt_mvar.t

fixes: https://github.com/rand00/conntest/issues/4
Signed-off-by: Prerna Dabi [prernadabi24@gmail.com](mailto:prernadabi24@gmail.com)
@rand00 